### PR TITLE
Specify node.js LTS release as minimum version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ please consider joining FINOS.
 
 ### Prerequisites
 
-- A recent version of node installed
+- Node.js 8.11.3 (LTS) or higher
 - A Node package manager (i.e. npm or yarn)
 - An API key: obtain a GreenKey API key by emailing your request to <mailto:sdk@greenkeytech.com>
 


### PR DESCRIPTION
This pull request updates README documentation to specify the current node.js long-term support release as a minimum version for SDK usage.

Fixes #5 