### PR TITLE
Change project name to 'greenkey-intercom-sdk' everywhere

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-GreenKey Voice SDK - FINOS
+GreenKey Intercom SDK - FINOS
 
 Copyright (c) 2019 Greenkey
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# GreenKey Voice SDK
+# GreenKey Intercom SDK
+
+[![FINOS - Archived](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-archived.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Archived)
 
 **NOTE**:  This project has been archived.  If anyone has any interest in using or continuing development, please contact the maintainers at <mailto:sdk@greenkeytech.com>
 
 > Voice-enable your front-end apps with instant intercoms
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/9412fdf333ef16f48ed6/maintainability)](https://codeclimate.com/github/finos/greenkey-voice-sdk/maintainability)
+[![Maintainability](https://api.codeclimate.com/v1/badges/5460ec9d6e2f31cd6aa3/maintainability)](https://codeclimate.com/github/finos/greenkey-intercom-sdk/maintainability)
 
-<img src="https://github.com/finos/greenkey-voice-sdk/raw/master/logo/greenkey-logo.png" width="132" />
+<img src="https://github.com/finos/greenkey-intercom-sdk/raw/master/logo/greenkey-logo.png" width="132" />
 
 ---
 
-The GreenKey Voice SDK
+The GreenKey Intercom SDK
 is the easiest way to embed instant intercom communication into your application.
 With minimal setup,
 your app can have push-to-talk technology,
@@ -20,7 +22,7 @@ to collaborate with colleagues in your community.
 This SDK provides front-end libraries and components
 which leverage the GreenKey telephony backend.
 
-The GreenKey Voice SDK
+The GreenKey Intercom SDK
 is hosted by the [Voice Program] of the Fintech Open Source Foundation ([FINOS]).
 If you are a company interested in the evolution of
 open standards, interoperability, and innovation in the financial services sector,
@@ -42,7 +44,7 @@ In the `package.json` file for your project, list the SDK as a dependency, and t
 
 ```json
   "dependencies": {
-    "greenkey-voice-sdk": "file:../sdk"
+    "greenkey-intercom-sdk": "file:../sdk"
   },
 ```
 
@@ -50,7 +52,7 @@ Then, from the top level directory of your project, run a command to install you
 
 `npm install` or `yarn `
 
-After that, the `greenkey-voice-sdk` should be added to your project's `node_modules/` folder.
+After that, the `greenkey-intercom-sdk` should be added to your project's `node_modules/` folder.
 
 Before the SDK will work,
 you will need to point it toward a URL endpoint
@@ -61,7 +63,7 @@ the GreenKey class in the SDK.
 
 See the [example projects](examples/) for the constants to set accordingly.
 
-You are now ready to begin using the GreenKey Voice SDK!
+You are now ready to begin using the GreenKey Intercom SDK!
 
 ## Learning
 
@@ -119,5 +121,5 @@ Copyright (c) 2019 Greenkey
 [Code of Conduct]: https://www.finos.org/code-of-conduct
 [Voice Program]: https://github.com/finos-voice/voice-program
 [SemVer]: http://semver.org
-[list of contributors]: https://github.com/finos/greenkey-voice-sdk/graphs/contributors
-[tags on this repository]: https://github.com/finos/greenkey-voice-sdk/tags
+[list of contributors]: https://github.com/finos/greenkey-intercom-sdk/graphs/contributors
+[tags on this repository]: https://github.com/finos/greenkey-intercom-sdk/tags

--- a/examples/es6/README.md
+++ b/examples/es6/README.md
@@ -1,4 +1,4 @@
-# GreenKey Voice SDK Example - Vanilla ES6
+# GreenKey Intercom SDK Example - Vanilla ES6
 
 This repository contains an example of using Vanilla ES6 to communicate with the GreenKey Voice backend.
 

--- a/examples/es6/app.js
+++ b/examples/es6/app.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 /* global document */
-import GreenKey from 'greenkey-voice-sdk';
+import GreenKey from 'greenkey-intercom-sdk';
 
 const endpoint = 'replace me';
 const GK = new GreenKey(`https://${endpoint}`);
@@ -231,7 +231,7 @@ const headerHTML = `
     <header class="navbar">
       <div class="container">
         <div class="navbar-brand" style="border-bottom: 1px solid #45D43C;">
-          <a class="navbar-item">GreenKey Voice SDK - ES6</a>
+          <a class="navbar-item">GreenKey Intercom SDK - ES6</a>
         </div>
       </div>
     </header>

--- a/examples/es6/index.html
+++ b/examples/es6/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
-  <title>GreenKey Voice SDK - ES6</title>
+  <title>GreenKey Intercom SDK - ES6</title>
   <link rel="shortcut icon" href="favicon.ico">
   <link rel="stylesheet" href="bulma.css">
   <link rel="stylesheet" href="custom.css">

--- a/examples/es6/package.json
+++ b/examples/es6/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "greenkey-voice-sdk-example-es6",
+  "name": "greenkey-intercom-sdk-example-es6",
   "version": "1.1.0",
-  "description": "GreenKey Voice SDK Example - ES6",
+  "description": "GreenKey Intercom SDK Example - ES6",
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "greenkey-voice-sdk": "file:../../"
+    "greenkey-intercom-sdk": "file:../../"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -1,4 +1,4 @@
-# GreenKey Voice SDK Example - Vue.js 2.0
+# GreenKey Intercom SDK Example - Vue.js 2.0
 
 This repository contains an example of using the Vue 2.0 framework to communicate with the GreenKey Voice backend.
 
@@ -23,7 +23,7 @@ cd examples/vue
 yarn
 ```
 
-Retrieve the public endpoint by [contacting GreenKey](http://greenkeytech.com/contact-us), then add your given endpoint URL to line 37 of `GreenKeyComponent.vue` (located in `greenkey-voice-sdk/examples/vue/src/components/GreenKeyComponent.vue`:
+Retrieve the public endpoint by [contacting GreenKey](http://greenkeytech.com/contact-us), then add your given endpoint URL to line 37 of `GreenKeyComponent.vue` (located in `greenkey-intercom-sdk/examples/vue/src/components/GreenKeyComponent.vue`:
 ```javascript
 const endpoint = 'some-endpoint.greenkeytech.com';
 ```

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "greenkey-voice-sdk-example-vue",
+  "name": "greenkey-intercom-sdk-example-vue",
   "description": "An example of the GreenKey SDK with Vue.js 2.0",
   "version": "1.1.0",
   "author": "AGiantSquid <ashley.e.shultz@gmail.com>",
@@ -12,7 +12,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "greenkey-voice-sdk": "file:../../",
+    "greenkey-intercom-sdk": "file:../../",
     "vue": "^2.5.11"
   },
   "devDependencies": {

--- a/examples/vue/public/index.html
+++ b/examples/vue/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
-    <title>GreenKey Voice SDK - Vue2</title>
+    <title>GreenKey Intercom SDK - Vue2</title>
     <link rel="stylesheet" href="./bulma.css">
   </head>
   <body>

--- a/examples/vue/src/components/GreenKeyComponent.vue
+++ b/examples/vue/src/components/GreenKeyComponent.vue
@@ -28,7 +28,7 @@
 
 <script>
 /* eslint-disable no-console */
-import GreenKey from 'greenkey-voice-sdk';
+import GreenKey from 'greenkey-intercom-sdk';
 import TheNavigationBar from './TheNavigationBar';
 import LoginComponent from './LoginComponent';
 import IntercomList from './IntercomList';

--- a/examples/vue/src/components/TheNavigationBar.vue
+++ b/examples/vue/src/components/TheNavigationBar.vue
@@ -9,7 +9,7 @@
     <header class="navbar">
       <div class="container">
         <div class="navbar-brand">
-          <a class="navbar-item">GreenKey Voice SDK - Vue2</a>
+          <a class="navbar-item">GreenKey Intercom SDK - Vue2</a>
         </div>
       </div>
     </header>

--- a/jsdoc/tutorials/GreenKeyClass.md
+++ b/jsdoc/tutorials/GreenKeyClass.md
@@ -1,7 +1,7 @@
-After installing `greenkey-voice-sdk.js` in your project, import it like any other module.
+After installing `greenkey-intercom-sdk.js` in your project, import it like any other module.
 
 ```javascript
-import GreenKey from 'greenkey-voice-sdk';
+import GreenKey from 'greenkey-intercom-sdk';
 ```
 
 Then you can initialize it with the target endpoint.

--- a/jsdoc/tutorials/creatingAnIntercom.md
+++ b/jsdoc/tutorials/creatingAnIntercom.md
@@ -1,13 +1,13 @@
 ### Before You Begin
 
- To use The GreenKey Voice SDK, you will need an API key for your account. [Contact a GreenKey administrator](http://greenkeytech.com/contact-us/) to obtain an API key for your development if you have not done so already. 
+ To use The GreenKey Intercom SDK, you will need an API key for your account. [Contact a GreenKey administrator](http://greenkeytech.com/contact-us/) to obtain an API key for your development if you have not done so already. 
 
 ### Initializing
 
-After installing `greenkey-voice-sdk.js` in your project, import it like any other module.
+After installing `greenkey-intercom-sdk.js` in your project, import it like any other module.
 
 ```javascript
-import GreenKey from 'greenkey-voice-sdk';
+import GreenKey from 'greenkey-intercom-sdk';
 ```
 
 Then you can initialize it with the target endpoint. The endpoint used for sandboxing is "`voice-sandbox.greenkeytech.com`".
@@ -19,7 +19,7 @@ const GK = new GreenKey(`https://${endpoint}`);
 
 ### User Creation
 
-You must have multiple accounts created before you can begin using the intercom functionality of the GreenKey Voice SDK. Let's create one now. All we need is a passphrase.
+You must have multiple accounts created before you can begin using the intercom functionality of the GreenKey Intercom SDK. Let's create one now. All we need is a passphrase.
 
 ```javascript
 // run the following in the body of an async function

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "greenkey-voice-sdk",
+  "name": "greenkey-intercom-sdk",
   "version": "1.0.0",
-  "description": "GreenKey Voice SDK",
+  "description": "GreenKey Intercom SDK",
   "main": "sdk.js",
   "scripts": {
     "lint": "eslint",

--- a/sdk.js
+++ b/sdk.js
@@ -17,7 +17,7 @@
 /* global window */
 
 /**
- * @module  greenkey-voice-sdk
+ * @module  greenkey-intercom-sdk
  */
 import feathers from '@feathersjs/client';
 import EventEmitter2 from 'eventemitter2';
@@ -28,7 +28,7 @@ import SIP from 'sip.js';
 /**
  * Class used to create and interact with intercoms.
  * @example
- * import GreenKey from 'greenkey-voice-sdk';
+ * import GreenKey from 'greenkey-intercom-sdk';
  * const GK = new GreenKey('test.example.com');
  * @tutorial GreenKeyClass
  */
@@ -90,7 +90,7 @@ class GreenKey {
         transportOptions,
         authorizationUser: '',
         password: '',
-        userAgentString: `GreenKey-Voice-SDK/${this.version}`,
+        userAgentString: `GreenKey-Intercom-SDK/${this.version}`,
         log: { level: 1 },
       });
 


### PR DESCRIPTION
Intercom SDK is a better, more specific name for what this old project does.
This will also make room for a GK Voice SDK with different functionality.

changes:

`s/Voice SDK/Intercom SDK/`
`s/voice-sdk/intercom-sdk/`

added FINOS archived badge.
